### PR TITLE
Various fixes

### DIFF
--- a/data-structures/base_linear.hpp
+++ b/data-structures/base_linear.hpp
@@ -21,13 +21,13 @@
 #include <stdlib.h>
 #include <string>
 
-#include "utils/default_hash.hpp"
+#include "../utils/default_hash.hpp"
 // #include "utils/output.hpp"
 // namespace otm = utils_tm::out_tm;
 
-#include "data-structures/base_linear_iterator.hpp"
-#include "data-structures/returnelement.hpp"
-#include "example/update_fcts.hpp"
+#include "../data-structures/base_linear_iterator.hpp"
+#include "../data-structures/returnelement.hpp"
+#include "../example/update_fcts.hpp"
 
 namespace growt
 {

--- a/data-structures/element_types/complex_slot.hpp
+++ b/data-structures/element_types/complex_slot.hpp
@@ -5,10 +5,10 @@
 #include <string>
 #include <tuple>
 
-#include "utils/debug.hpp"
+#include "../../utils/debug.hpp"
 namespace debug = utils_tm::debug_tm;
 
-#include "data-structures/returnelement.hpp"
+#include "../returnelement.hpp"
 
 namespace growt
 {

--- a/data-structures/element_types/complex_slot.hpp
+++ b/data-structures/element_types/complex_slot.hpp
@@ -270,7 +270,7 @@ typename complex_slot<K, D, m, A>::key_type
 complex_slot<K, D, m, A>::slot_type::get_key() const
 {
     auto ptr = reinterpret_cast<value_type*>(_mfptr.split.pointer);
-    if (!ptr)
+    if (!ptr || _mfptr.full == 1ull << 48)
     {
         debug::if_debug("getting key from empty slot");
         return key_type();
@@ -283,7 +283,7 @@ const typename complex_slot<K, D, m, A>::key_type&
 complex_slot<K, D, m, A>::slot_type::get_key_ref() const
 {
     auto ptr = reinterpret_cast<value_type*>(_mfptr.split.pointer);
-    if (!ptr) { debug::if_debug("getting key from empty slot"); }
+    if (!ptr || _mfptr.full == 1ull << 48) { debug::if_debug("getting key from empty slot"); }
     return ptr->first;
 }
 
@@ -292,7 +292,7 @@ typename complex_slot<K, D, m, A>::mapped_type
 complex_slot<K, D, m, A>::slot_type::get_mapped() const
 {
     auto ptr = reinterpret_cast<value_type*>(_mfptr.split.pointer);
-    if (!ptr)
+    if (!ptr || _mfptr.full == 1ull << 48)
     {
         debug::if_debug("getting mapped from empty slot");
         return mapped_type();
@@ -305,7 +305,7 @@ const typename complex_slot<K, D, m, A>::value_type*
 complex_slot<K, D, m, A>::slot_type::get_pointer() const
 {
     auto ptr = reinterpret_cast<value_type*>(_mfptr.split.pointer);
-    if (!ptr) { debug::if_debug("getting pointer from an empty slot"); }
+    if (!ptr || _mfptr.full == 1ull << 48) { debug::if_debug("getting pointer from an empty slot"); }
     return ptr;
 }
 
@@ -314,7 +314,7 @@ typename complex_slot<K, D, m, A>::value_type*
 complex_slot<K, D, m, A>::slot_type::get_pointer()
 {
     auto ptr = reinterpret_cast<value_type*>(_mfptr.split.pointer);
-    if (!ptr) { debug::if_debug("getting key from empty slot"); }
+    if (!ptr || _mfptr.full == 1ull << 48) { debug::if_debug("getting key from empty slot"); }
     return ptr;
 }
 
@@ -351,7 +351,7 @@ bool complex_slot<K, D, m, A>::slot_type::compare_key(const key_type& k,
 {
     if (fingerprint(hash) != _mfptr.split.fingerprint) return false;
     auto ptr = reinterpret_cast<value_type*>(_mfptr.split.pointer);
-    if (ptr == nullptr)
+    if (ptr == nullptr || _mfptr.full == 1ull << 48)
     {
         // debug::if_debug("comparison with an empty slot");
         return false;
@@ -364,7 +364,7 @@ template <class K, class D, bool m, class A>
 complex_slot<K, D, m, A>::slot_type::operator value_type() const
 {
     auto ptr = reinterpret_cast<value_type*>(_mfptr.split.pointer);
-    if (ptr == nullptr)
+    if (ptr == nullptr || _mfptr.full == 1ull << 48)
     {
         debug::if_debug("getting value_type from empty slot");
     }
@@ -415,7 +415,7 @@ template <class K, class D, bool m, class A>
 void complex_slot<K, D, m, A>::slot_type::cleanup()
 {
     auto ptr = reinterpret_cast<value_type*>(_mfptr.split.pointer);
-    if (!ptr)
+    if (!ptr || _mfptr.full == 1ull << 48)
     {
         // debug::if_debug("cleanup on empty slot");
         return;

--- a/data-structures/element_types/complex_slot.hpp
+++ b/data-structures/element_types/complex_slot.hpp
@@ -183,7 +183,7 @@ class complex_slot
     static std::string name() { return "complex_slot"; }
 
   private:
-    static allocator_type allocator;
+    inline static allocator_type allocator;
 };
 
 
@@ -491,7 +491,7 @@ bool complex_slot<K, D, m, A>::atomic_slot_type::atomic_delete(
     slot_type& expected)
 {
     return _aptr.compare_exchange_strong(expected._mfptr.full,
-                                         get_deleted._mfptr.full,
+                                         get_deleted()._mfptr.full,
                                          std::memory_order_relaxed);
 }
 

--- a/data-structures/element_types/seq_complex_slot.hpp
+++ b/data-structures/element_types/seq_complex_slot.hpp
@@ -219,7 +219,7 @@ typename seq_complex_slot<K, D>::key_type
 seq_complex_slot<K, D>::slot_type::get_key() const
 {
     auto ptr = reinterpret_cast<value_type*>(_mfptr.split.pointer);
-    if (!ptr)
+    if (!ptr || _mfptr.full == 1ull << 48)
     {
         debug::if_debug("getting key from empty slot");
         return key_type();
@@ -232,7 +232,7 @@ const typename seq_complex_slot<K, D>::key_type&
 seq_complex_slot<K, D>::slot_type::get_key_ref() const
 {
     auto ptr = reinterpret_cast<value_type*>(_mfptr.split.pointer);
-    if (!ptr) { debug::if_debug("getting key from empty slot"); }
+    if (!ptr || _mfptr.full == 1ull << 48) { debug::if_debug("getting key from empty slot"); }
     return ptr->first;
 }
 
@@ -241,7 +241,7 @@ typename seq_complex_slot<K, D>::mapped_type
 seq_complex_slot<K, D>::slot_type::get_mapped() const
 {
     auto ptr = reinterpret_cast<value_type*>(_mfptr.split.pointer);
-    if (!ptr)
+    if (!ptr || _mfptr.full == 1ull << 48)
     {
         debug::if_debug("getting mapped from empty slot");
         return mapped_type();
@@ -369,7 +369,7 @@ bool seq_complex_slot<K, D>::slot_type::operator!=(const slot_type& r) const
 template <class K, class D> void seq_complex_slot<K, D>::slot_type::cleanup()
 {
     auto ptr = reinterpret_cast<value_type*>(_mfptr.split.pointer);
-    if (!ptr) { return; }
+    if (!ptr || _mfptr.full == 1ull << 48) { return; }
     seq_complex_slot::deallocate(ptr);
 }
 

--- a/data-structures/element_types/simple_slot.hpp
+++ b/data-structures/element_types/simple_slot.hpp
@@ -10,7 +10,7 @@
 
 #include <atomic>
 
-#include "utils/debug.hpp"
+#include "../../utils/debug.hpp"
 namespace debug = utils_tm::debug_tm;
 
 #ifndef ICPC
@@ -20,7 +20,7 @@ using int128_t = __int128;
 using int128_t = __int128_t;
 #endif
 
-#include "data-structures/returnelement.hpp"
+#include "../../data-structures/returnelement.hpp"
 
 namespace growt
 {

--- a/data-structures/element_types/single_word_slot.hpp
+++ b/data-structures/element_types/single_word_slot.hpp
@@ -10,11 +10,11 @@
 
 #include <atomic>
 
-#include "utils/concurrency/memory_order.hpp"
-#include "utils/debug.hpp"
+#include "../../utils/concurrency/memory_order.hpp"
+#include "../../utils/debug.hpp"
 namespace debug = utils_tm::debug_tm;
 
-#include "data-structures/returnelement.hpp"
+#include "../../data-structures/returnelement.hpp"
 
 namespace growt
 {

--- a/data-structures/migration_table.hpp
+++ b/data-structures/migration_table.hpp
@@ -25,9 +25,9 @@
 #include <string>
 
 
-#include "data-structures/migration_table_iterator.hpp"
-#include "data-structures/returnelement.hpp"
-#include "example/update_fcts.hpp"
+#include "../data-structures/migration_table_iterator.hpp"
+#include "../data-structures/returnelement.hpp"
+#include "../example/update_fcts.hpp"
 
 namespace growt
 {

--- a/data-structures/strategies/estrat_async.hpp
+++ b/data-structures/strategies/estrat_async.hpp
@@ -16,9 +16,9 @@
 #include <mutex>
 #include <string>
 
-#include "utils/debug.hpp"
+#include "../../utils/debug.hpp"
 namespace dtm = utils_tm::debug_tm;
-#include "utils/memory_reclamation/counting_reclamation.hpp"
+#include "../../utils/memory_reclamation/counting_reclamation.hpp"
 namespace rtm = utils_tm::reclamation_tm;
 
 /*******************************************************************************

--- a/data-structures/strategies/estrat_sync.hpp
+++ b/data-structures/strategies/estrat_sync.hpp
@@ -17,10 +17,10 @@
 #include <stdexcept>
 #include <string>
 
-#include "utils/mark_pointer.hpp"
+#include "../../utils/mark_pointer.hpp"
 namespace mark = utils_tm::mark;
 
-#include "utils/debug.hpp"
+#include "../../utils/debug.hpp"
 namespace dtm = utils_tm::debug_tm;
 
 /*******************************************************************************

--- a/data-structures/table_config.hpp
+++ b/data-structures/table_config.hpp
@@ -3,18 +3,18 @@
 #include <sstream>
 #include <type_traits>
 
-#include "data-structures/element_types/complex_slot.hpp"
-#include "data-structures/element_types/simple_slot.hpp"
-#include "data-structures/element_types/single_word_slot.hpp"
+#include "element_types/complex_slot.hpp"
+#include "element_types/simple_slot.hpp"
+#include "element_types/single_word_slot.hpp"
 
-#include "data-structures/strategies/estrat_async.hpp"
-#include "data-structures/strategies/estrat_sync.hpp"
-#include "data-structures/strategies/wstrat_pool.hpp"
-#include "data-structures/strategies/wstrat_user.hpp"
+#include "strategies/estrat_async.hpp"
+#include "strategies/estrat_sync.hpp"
+#include "strategies/wstrat_pool.hpp"
+#include "strategies/wstrat_user.hpp"
 
-#include "data-structures/base_linear.hpp"
-#include "data-structures/hash_table_mods.hpp"
-#include "data-structures/migration_table.hpp"
+#include "base_linear.hpp"
+#include "hash_table_mods.hpp"
+#include "migration_table.hpp"
 
 namespace growt
 {

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -2,16 +2,16 @@
 #include <random>
 #include <thread>
 
-#include "allocator/alignedallocator.hpp"
-#include "data-structures/hash_table_mods.hpp"
-#include "utils/hash/murmur2_hash.hpp"
+#include "../allocator/alignedallocator.hpp"
+#include "../data-structures/hash_table_mods.hpp"
+#include "../utils/hash/murmur2_hash.hpp"
 
 using hasher_type    = utils_tm::hash_tm::murmur2_hash;
 using allocator_type = growt::AlignedAllocator<>;
 
 //////////////////////////////////////////////////////////////
 // USING definitions.h (possibly slower compilation)
-#include "data-structures/table_config.hpp"
+#include "../data-structures/table_config.hpp"
 
 using table_type =
     typename growt::table_config<size_t, size_t, hasher_type, allocator_type,

--- a/example/range_example.cpp
+++ b/example/range_example.cpp
@@ -4,16 +4,16 @@
 #include <thread>
 
 
-#include "allocator/alignedallocator.hpp"
-#include "data-structures/hash_table_mods.hpp"
-#include "utils/hash/murmur2_hash.hpp"
+#include "../allocator/alignedallocator.hpp"
+#include "../data-structures/hash_table_mods.hpp"
+#include "../utils/hash/murmur2_hash.hpp"
 
 using hasher_type    = utils_tm::hash_tm::murmur2_hash;
 using allocator_type = growt::AlignedAllocator<>;
 
 //////////////////////////////////////////////////////////////
 // USING definitions.h (possibly slower compilation)
-#include "data-structures/table_config.hpp"
+#include "../data-structures/table_config.hpp"
 
 using table_type =
     typename growt::table_config<size_t, size_t, hasher_type, allocator_type,


### PR DESCRIPTION
Hello!

My attempt to adopt this library for the project's use has ended up in several fixes.

## 1. Build fix:
the call braces were missed in one place, and it turns out that a static field requires an explicit definition, so luckily there's `inline` key in c++17.

## 2. Empty pointer fix:
I don't have a good understanding of what's going on there, but I saw 1 << 48 inside the pointer value very frequently, so I have protected all the places where the pointer is fetched from this markable-taggable reference.

Maybe it's just supposed to be the `mark` bit, i don't know. Please take a look at it, maybe `ptr_split` itself should be fixed.

Also, I suggest to redesign `ptr_split` to use masks and shifts, and to make accessors to those fields.
The reason is that the bit fields layout is implementation-defined:
1. On big-endian architcture, "full" can be not what you expect (one might expect a pointer, if tag and mark are zero)
2. The bitfield layout and alignment is implementation-defined, so it may vary from a combination of abi and compiler. 

Maybe, here it's not a case, if a pointer is never assigned through "full", but the 48'th bit problem suggests a need for a look of some thoroughness. I wonder about the author's opinion.

## 3. Fix include paths
When used as a Library, the root tipically won't be in the include_directories list. So the relative paths should be used. I have also fixed the paths in the examples, though it's not required there

Best regards